### PR TITLE
fix: modernize MPI Fortran API for strict gfortran 13 + OpenMPI

### DIFF
--- a/src/Core/scribe_io.F90
+++ b/src/Core/scribe_io.F90
@@ -188,19 +188,19 @@
         !systems
         do i=1,nproc_compute
           call mpi_irecv(itmp,1,itype,i-1,199,comm_schism,rrqst,ierr)
-          call mpi_wait(rrqst,MPI_STATUSES_IGNORE,ierr)
+          call mpi_wait(rrqst,MPI_STATUS_IGNORE,ierr)
           np(i)=itmp
         enddo !i
 
         do i=1,nproc_compute
           call mpi_irecv(itmp,1,itype,i-1,198,comm_schism,rrqst,ierr)
-          call mpi_wait(rrqst,MPI_STATUSES_IGNORE,ierr)
+          call mpi_wait(rrqst,MPI_STATUS_IGNORE,ierr)
           ne(i)=itmp
         enddo !i
 
         do i=1,nproc_compute
           call mpi_irecv(itmp,1,itype,i-1,197,comm_schism,rrqst,ierr)
-          call mpi_wait(rrqst,MPI_STATUSES_IGNORE,ierr)
+          call mpi_wait(rrqst,MPI_STATUS_IGNORE,ierr)
           ns(i)=itmp
         enddo !i
 
@@ -258,32 +258,32 @@
         !Other vars using index arrays
         do i=1,nproc_compute
           call mpi_irecv(work,np(i),rtype,i-1,193,comm_schism,rrqst,ierr)
-          call mpi_wait(rrqst,MPI_STATUSES_IGNORE,ierr)
+          call mpi_wait(rrqst,MPI_STATUS_IGNORE,ierr)
           xnd(iplg(1:np(i),i))=work(1:np(i))
         enddo !i
         do i=1,nproc_compute
           call mpi_irecv(work,np(i),rtype,i-1,192,comm_schism,rrqst,ierr)
-          call mpi_wait(rrqst,MPI_STATUSES_IGNORE,ierr)
+          call mpi_wait(rrqst,MPI_STATUS_IGNORE,ierr)
           ynd(iplg(1:np(i),i))=work(1:np(i))
         enddo !i
         do i=1,nproc_compute
           call mpi_irecv(work,np(i),rtype,i-1,191,comm_schism,rrqst,ierr)
-          call mpi_wait(rrqst,MPI_STATUSES_IGNORE,ierr)
+          call mpi_wait(rrqst,MPI_STATUS_IGNORE,ierr)
           dp(iplg(1:np(i),i))=work(1:np(i))
         enddo !i
         do i=1,nproc_compute
           call mpi_irecv(iwork,np(i),itype,i-1,190,comm_schism,rrqst,ierr)
-          call mpi_wait(rrqst,MPI_STATUSES_IGNORE,ierr)
+          call mpi_wait(rrqst,MPI_STATUS_IGNORE,ierr)
           kbp00(iplg(1:np(i),i))=iwork(1:np(i))
         enddo !i
         do i=1,nproc_compute
           call mpi_irecv(iwork,ne(i),itype,i-1,189,comm_schism,rrqst,ierr)
-          call mpi_wait(rrqst,MPI_STATUSES_IGNORE,ierr)
+          call mpi_wait(rrqst,MPI_STATUS_IGNORE,ierr)
           i34(ielg(1:ne(i),i))=iwork(1:ne(i))
         enddo !i
         do i=1,nproc_compute
           call mpi_irecv(iwork2,4*ne(i),itype,i-1,188,comm_schism,rrqst,ierr)
-          call mpi_wait(rrqst,MPI_STATUSES_IGNORE,ierr)
+          call mpi_wait(rrqst,MPI_STATUS_IGNORE,ierr)
 
           do j=1,ne(i)
             iegb=ielg(j,i)
@@ -295,7 +295,7 @@
 
         do i=1,nproc_compute
           call mpi_irecv(iwork3,2*ns(i),itype,i-1,187,comm_schism,rrqst,ierr)
-          call mpi_wait(rrqst,MPI_STATUSES_IGNORE,ierr)
+          call mpi_wait(rrqst,MPI_STATUS_IGNORE,ierr)
           do j=1,ns(i)
             isgb=islg(j,i)
             isidenode(1,isgb)=iplg(iwork3(1,j),i)

--- a/src/Hydro/bktrk_subs.F90
+++ b/src/Hydro/bktrk_subs.F90
@@ -219,10 +219,10 @@ subroutine inter_btrack(itime,nbt,btlist)
   do inbr=1,nnbr
     if(nbtsend(inbr)/=0) then
 #if MPIVERSION==1
-      call mpi_type_indexed(nbtsend(inbr),bbtsend,ibtsend(1,inbr),bt_mpitype, &
+      call mpi_type_indexed(nbtsend(inbr),bbtsend,ibtsend(:,inbr),bt_mpitype, &
       btsend_type(inbr),ierr)
 #elif MPIVERSION==2
-      call mpi_type_create_indexed_block(nbtsend(inbr),1,ibtsend(1,inbr),bt_mpitype, &
+      call mpi_type_create_indexed_block(nbtsend(inbr),1,ibtsend(:,inbr),bt_mpitype, &
       btsend_type(inbr),ierr)
 #endif
       if(ierr/=MPI_SUCCESS) call parallel_abort('INTER_BTRACK: create btsend_type',ierr)
@@ -264,10 +264,10 @@ subroutine inter_btrack(itime,nbt,btlist)
       do j=1,nbtrecv(inbr); ibtrecv(j,inbr)=i+j-1; enddo; !displacement
       i=i+nbtrecv(inbr)
 #if MPIVERSION==1
-      call mpi_type_indexed(nbtrecv(inbr),bbtrecv,ibtrecv(1,inbr),bt_mpitype, &
+      call mpi_type_indexed(nbtrecv(inbr),bbtrecv,ibtrecv(:,inbr),bt_mpitype, &
       btrecv_type(inbr),ierr)
 #elif MPIVERSION==2
-      call mpi_type_create_indexed_block(nbtrecv(inbr),1,ibtrecv(1,inbr),bt_mpitype, &
+      call mpi_type_create_indexed_block(nbtrecv(inbr),1,ibtrecv(:,inbr),bt_mpitype, &
       btrecv_type(inbr),ierr)
 #endif
       if(ierr/=MPI_SUCCESS) call parallel_abort('INTER_BTRACK: create btrecv_type',ierr)
@@ -544,10 +544,10 @@ subroutine inter_btrack(itime,nbt,btlist)
     if(nbtsend(irank)/=0) then
       if(irank==myrank) call parallel_abort('INTER_BTRACK: self communication (1)')
 #if MPIVERSION==1
-      call mpi_type_indexed(nbtsend(irank),bbtsend,ibtsend(1,irank),bt_mpitype, &
+      call mpi_type_indexed(nbtsend(irank),bbtsend,ibtsend(:,irank),bt_mpitype, &
       btsend_type(irank),ierr)
 #elif MPIVERSION==2
-      call mpi_type_create_indexed_block(nbtsend(irank),1,ibtsend(1,irank),bt_mpitype, &
+      call mpi_type_create_indexed_block(nbtsend(irank),1,ibtsend(:,irank),bt_mpitype, &
       btsend_type(irank),ierr)
 #endif
       if(ierr/=MPI_SUCCESS) call parallel_abort('INTER_BTRACK: create btsend_type',ierr)
@@ -564,10 +564,10 @@ subroutine inter_btrack(itime,nbt,btlist)
       do j=1,nbtrecv(irank); ibtrecv(j,irank)=i+j-1; enddo; !displacement
       i=i+nbtrecv(irank)
 #if MPIVERSION==1
-      call mpi_type_indexed(nbtrecv(irank),bbtrecv,ibtrecv(1,irank),bt_mpitype, &
+      call mpi_type_indexed(nbtrecv(irank),bbtrecv,ibtrecv(:,irank),bt_mpitype, &
       btrecv_type(irank),ierr)
 #elif MPIVERSION==2
-      call mpi_type_create_indexed_block(nbtrecv(irank),1,ibtrecv(1,irank),bt_mpitype, &
+      call mpi_type_create_indexed_block(nbtrecv(irank),1,ibtrecv(:,irank),bt_mpitype, &
       btrecv_type(irank),ierr)
 #endif
       if(ierr/=MPI_SUCCESS) call parallel_abort('INTER_BTRACK: create btrecv_type',ierr)

--- a/src/Hydro/schism_init.F90
+++ b/src/Hydro/schism_init.F90
@@ -2768,10 +2768,10 @@
           do i=0,nproc-1
             if(nhtsend1(i)/=0) then
 #if MPIVERSION==1
-              call mpi_type_indexed(nhtsend1(i),send_bsize,ihtsend1(1,i),rtype, &
+              call mpi_type_indexed(nhtsend1(i),send_bsize,ihtsend1(:,i),rtype, &
      &htsend_type(i),ierr)
 #elif MPIVERSION==2
-              call mpi_type_create_indexed_block(nhtsend1(i),1,ihtsend1(1,i),rtype, &
+              call mpi_type_create_indexed_block(nhtsend1(i),1,ihtsend1(:,i),rtype, &
      &htsend_type(i),ierr)
 #endif
               if(ierr/=MPI_SUCCESS) call parallel_abort('MAIN: create htsend_type',ierr)
@@ -2787,10 +2787,10 @@
           do i=0,nproc-1
             if(nhtrecv1(i)/=0) then
 #if MPIVERSION==1
-              call mpi_type_indexed(nhtrecv1(i),recv_bsize,ihtrecv1(1,i),rtype, &
+              call mpi_type_indexed(nhtrecv1(i),recv_bsize,ihtrecv1(:,i),rtype, &
      &htrecv_type(i),ierr)
 #elif MPIVERSION==2
-              call mpi_type_create_indexed_block(nhtrecv1(i),1,ihtrecv1(1,i),rtype, &
+              call mpi_type_create_indexed_block(nhtrecv1(i),1,ihtrecv1(:,i),rtype, &
      &htrecv_type(i),ierr)
 #endif
               if(ierr/=MPI_SUCCESS) call parallel_abort('MAIN: create htrecv_type',ierr)


### PR DESCRIPTION
- Fix mpi_wait calls to use MPI_STATUS_IGNORE instead of MPI_STATUSES_IGNORE (mpi_wait expects singular status, not array)

- Fix array passing in mpi_type_indexed and mpi_type_create_indexed_block to use explicit array sections (:,index) instead of scalar element references (1,index) for compatibility with modern Fortran MPI interfaces

Files modified:
- src/Core/scribe_io.F90: 10 mpi_wait fixes
- src/Hydro/bktrk_subs.F90: 8 array section fixes
- src/Hydro/schism_init.F90: 4 array section fixes